### PR TITLE
add messaging_type and upgrade api version

### DIFF
--- a/lib/messenger_bot.js
+++ b/lib/messenger_bot.js
@@ -9,7 +9,7 @@ const cloneDeep = require('lodash').cloneDeep;
 const BaseBot = require('botmaster').BaseBot;
 const debug = require('debug')('botmaster:messenger');
 
-const apiVersion = '2.10';
+const apiVersion = '2.11';
 const baseURL = `https://graph.facebook.com/v${apiVersion}`;
 const baseMessageURL = `${baseURL}/me/messages`;
 const baseMessengerProfileURL = `${baseURL}/me/messenger_profile`;
@@ -158,8 +158,9 @@ class MessengerBot extends BaseBot {
     }
   }
 
-  // doesn't actually do anything in messenger bot
+  // doesn't actually do anything in messenger bot except for add the messaging_type
   __formatOutgoingMessage(outgoingMessage) {
+    outgoingMessage.messaging_type = 'RESPONSE';
     return Promise.resolve(outgoingMessage);
   }
 


### PR DESCRIPTION
From may 2018 messages sent without this field will be rejected: https://developers.facebook.com/docs/messenger-platform/reference/send-api/