### PR TITLE
Escape needed characters to calculate expectedHash

### DIFF
--- a/lib/charToEscapedMap.js
+++ b/lib/charToEscapedMap.js
@@ -1,0 +1,27 @@
+// Object that maps each special character, that needs to be escaped, to its escaped representation
+module.exports = {
+  'á': '\\u00e1',
+  'à': '\\u00e0',
+  'â': '\\u00e2',
+  'ä': '\\u00e4',
+  'é': '\\u00e9',
+  'è': '\\u00e8',
+  'ê': '\\u00ea',
+  'ë': '\\u00eb',
+  'í': '\\u00ed',
+  'ì': '\\u00ec',
+  'î': '\\u00ee',
+  'ï': '\\u00ef',
+  'ó': '\\u00f3',
+  'ò': '\\u00f2',
+  'ô': '\\u00f4',
+  'ö': '\\u00f6',
+  'ú': '\\u00fa',
+  'ù': '\\u00f9',
+  'û': '\\u00fb',
+  'ü': '\\u00fc',
+  '/': '\/',
+  '<': '\\u003C',
+  '%': '\\u0025',
+  '@': '\\u0040'
+}

--- a/lib/messenger_bot.js
+++ b/lib/messenger_bot.js
@@ -8,6 +8,7 @@ const merge = require('lodash').merge;
 const cloneDeep = require('lodash').cloneDeep;
 const BaseBot = require('botmaster').BaseBot;
 const debug = require('debug')('botmaster:messenger');
+const charToEscapedMap = require('./charToEscapedMap')
 
 const apiVersion = '2.11';
 const baseURL = `https://graph.facebook.com/v${apiVersion}`;
@@ -167,9 +168,16 @@ class MessengerBot extends BaseBot {
   __verifyRequestSignature(req, res, buf) {
     const signature = req.headers['x-hub-signature'];
     const signatureHash = signature ? signature.split('=')[1] : undefined;
+    let bufString = buf.toString('utf8');
+    
+    for(let char in charToEscapedMap) {
+      bufString = bufString.replace(char, charToEscapedMap[char]);
+    }
+    
     const expectedHash = crypto.createHmac('sha1', this.credentials.fbAppSecret)
-                        .update(buf)
-                        .digest('hex');
+                      .update(bufString)
+                      .digest('hex');
+
     if (signatureHash !== expectedHash) {
       throw new Error('wrong signature');
     }


### PR DESCRIPTION
Before calculating the hash that is sent by facebook it escapes some special characters,
so to verify if the incoming hash is right it is needed to also escape the same characters.

This code maps some special characters that needed escaping.

More about this on [facebook](https://developers.facebook.com/docs/messenger-platform/webhook/#security)

Possible enhancements of the code are:
* use a Map instead of an ordinary object to map the characters
* check efficiency of executing multiple replaces at the same time using [regex](https://stackoverflow.com/questions/15604140/replace-multiple-strings-with-multiple-other-strings)
* A better way to know which characters should be escpaded and which don't